### PR TITLE
Check that delayed event handler exist in new state before calling it

### DIFF
--- a/lib/Class/StateMachine.pm
+++ b/lib/Class/StateMachine.pm
@@ -104,7 +104,9 @@ sub _state {
         for (0..$delayed_top) {
             my $action = shift @$delayed;
             $debug and _debug($self, "running delayed action $action");
-            $self->$action;
+            if( my $method = $self->can($action) ) {
+                $self->$method;
+            }
             return $state{$self} if $state_changed{$self};
         }
     }

--- a/lib/Class/StateMachine.pm
+++ b/lib/Class/StateMachine.pm
@@ -104,7 +104,9 @@ sub _state {
         for (0..$delayed_top) {
             my $action = shift @$delayed;
             $debug and _debug($self, "running delayed action $action");
-            if( my $method = $self->can($action) ) {
+            if (ref $action) {
+                $self->$action;
+            elsif (my $method = $self->can($action)) {
                 $self->$method;
             }
             return $state{$self} if $state_changed{$self};

--- a/lib/Class/StateMachine.pm
+++ b/lib/Class/StateMachine.pm
@@ -106,6 +106,7 @@ sub _state {
             $debug and _debug($self, "running delayed action $action");
             if (ref $action) {
                 $self->$action;
+            }
             elsif (my $method = $self->can($action)) {
                 $self->$method;
             }


### PR DESCRIPTION
Since delayed methods are executed in new state context, it is possible to switch to such state where these events are not defined
(i.e. no such methods exist or inherited)
this would be runtime error, so to prevent it we need to check wheneve this event handler exists before calling it